### PR TITLE
Add tokenlist with gas estimates for DAI

### DIFF
--- a/frontend/src/data/tokenlist.json
+++ b/frontend/src/data/tokenlist.json
@@ -1,0 +1,25 @@
+{
+  "name": "Zeneth",
+  "version": {
+    "major": 0,
+    "minor": 0,
+    "patch": 1
+  },
+  "keywords": ["zeneth", "flashbots", "mev", "gasless", "defi"],
+  "tokens": [
+    {
+      "chainId": 1,
+      "address": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+      "name": "Dai",
+      "symbol": "DAI",
+      "decimals": 18,
+      "logoURI": "https://assets.coingecko.com/coins/images/9956/thumb/dai-multi-collateral-mcd.png?1574218774",
+      "gasEstimates": {
+        "approve": 47000,
+        "transfer": 54500,
+        "swapAndBribe": 200000
+      }
+    }
+  ],
+  "timestamp": "2021-04-23T20:11:22.472Z"
+}


### PR DESCRIPTION
Adds a hardcoded token list for use in the frontend with the an additional field, `gasEstimates`, which is a mapping of gas limits to use for operations with this token. This PR contains only the DAI token, and provides estimates for the following operations, which are needed for gasless token transfer:

1.  `approve` based on [this query](https://duneanalytics.com/queries/59517)
2. `transfer` based on [this query](https://duneanalytics.com/queries/54330)
3. `swapAndBribe` based on a padding applied to [this transaction](https://etherscan.io/tx/0x90f16b53efde82ad4cb3eed92c43bb8bf234b6009d1d24a8ec51c4be5052dd7f)

Note that the estimates for 1 & 2 are based on the high band of gas costs reported, ignoring unexplained high anomalies, and with a bit of padding applied for round numbers. As such, they should represent the "worst case" gas costs based on balances and refunds.

Note that number 3 is far from an exact science. A better approach would be to use queries for each of the sub-calls and add padding, but this has proven difficult to achieve so far with Dune.

We can improve these estimates across the board, and we still need estimates for additional tokens, but this should give us what we need to get something working and testable for Dai transfers on mainnet.